### PR TITLE
INFRADEV-11978: Simplify vacuum query

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -64,7 +64,7 @@ def create_app(config=None):
     app.logger.info("Started")
 
     Mail(app)
-    
+
     if os.environ.get("SQLALCHEMY_LOG_QUERIES"):
         logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
 

--- a/flask_app/tasks.py
+++ b/flask_app/tasks.py
@@ -28,18 +28,19 @@ from celery.signals import after_setup_logger, after_setup_task_logger
 from celery.log import redirect_stdouts_to_logger
 from raven.contrib.celery import register_signal
 
-from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import exists
 from typing import Any
+from sqlalchemy.orm import joinedload
+from sqlalchemy.orm.query import Query
+from sqlalchemy import bindparam, func, extract, text, or_, and_, case, update
 
 import flux
 
 from .app import create_app, needs_app_context
 from . import issue_trackers
-from .models import Beam, db, Pin, File, Tracker, Issue, beam_issues
 from .paths import get_combadge_path
+from .models import Beam, db, Pin, File, Tracker, Issue, BeamType, beam_issues
 from flask import current_app
-
 
 
 logger = logbook.Logger(__name__)
@@ -262,6 +263,35 @@ def remind_pinned() -> None:
     s.quit()
 
 
+@needs_app_context
+def get_pending_query():
+    now = flux.current_timeline.datetime.utcnow()
+    days_factor = 60 * 60 * 24
+    beam_age_in_days = func.trunc(extract('epoch', now) - extract('epoch', Beam.start)) / days_factor
+    vacuum_threshold = case([(Beam.type_id == None, current_app.config['VACUUM_THRESHOLD']),], else_ = BeamType.vacuum_threshold)
+
+    existing_open_issues = db.session.query(beam_issues.c.beam_id)
+                                     .join(Issue, Issue.id == beam_issues.c.issue_id)
+                                     .filter(beam_issues.c.beam_id == Beam.id,
+                                             Issue.open)
+                                     .exists()
+
+    pending_query = db.session.query(Beam.id)
+                              .outerjoin(Pin, Pin.beam_id == Beam.id)
+                              .outerjoin(BeamType, BeamType.id == Beam.id)
+                              .outerjoin(File, File.beam_id == Beam.id)
+                              .filter(~Beam.pending_deletion,
+                                      ~Beam.deleted,
+                                      Beam.completed,
+                                      Pin.id == None,
+                                      ~existing_open_issues,
+                                      and_(
+                                          File.beam_id == None,
+                                          beam_age_in_days >= vacuum_threshold
+                                      ))
+    return pending_query
+
+
 @queue.task
 @needs_app_context
 def vacuum() -> None:
@@ -272,27 +302,9 @@ def vacuum() -> None:
     # must create this empty file in the storage directory
     os.stat(os.path.join(current_app.config['STORAGE_PATH'], ".test"))
 
-    db.engine.execute(
-        """UPDATE beam SET pending_deletion=true WHERE beam.id IN (
-        SELECT beam.id FROM beam
-        LEFT JOIN pin ON pin.beam_id = beam.id
-        LEFT JOIN beam_type ON beam.type_id = beam_type.id
-        LEFT JOIN file ON file.beam_id = beam.id
-        WHERE
-        NOT beam.pending_deletion
-        AND NOT beam.deleted
-        AND beam.completed
-        AND pin.id IS NULL
-        AND NOT EXISTS (
-            SELECT id FROM beam_issues
-            INNER JOIN issue ON issue.id = beam_issues.issue_id
-            WHERE beam_issues.beam_id = beam.id
-            AND issue.open)
-        AND (
-            file.beam_id IS NULL
-            OR ((beam.type_id IS NULL) AND (beam.start < %s - '%s days'::interval))
-            OR ((beam.type_id IS NOT NULL) AND (beam.start < %s - (beam_type.vacuum_threshold * INTERVAL '1 DAY')))
-        ))""", now, current_app.config['VACUUM_THRESHOLD'], now)
+    pending_query = get_pending_query()
+    update(Beam).where(Beam.id.in_(pending_query)).values(pending_deletion=True)
+
     db.session.commit()
     logger.info("Finished marking vacuum candidates")
 


### PR DESCRIPTION
Changes the vacuum query from:

SELECT beam.id FROM beam
LEFT JOIN pin ON pin.beam_id = beam.id
LEFT JOIN beam_type ON beam.type_id = beam_type.id
LEFT JOIN file ON file.beam_id = beam.id
WHERE
NOT beam.pending_deletion
AND NOT beam.deleted
AND beam.completed
AND pin.id IS NULL
AND NOT EXISTS (
    SELECT id FROM beam_issues
    INNER JOIN issue ON issue.id = beam_issues.issue_id
    WHERE beam_issues.beam_id = beam.id
    AND issue.open)
AND (
     file.beam_id IS NULL
     OR ((beam.type_id IS NULL) AND (beam.start < now - 'APP.config['VACUUM_THRESHOLD'] days'::interval))
     OR ((beam.type_id IS NOT NULL) AND (beam.start < now - (beam_type.vacuum_threshold * INTERVAL '1 DAY')))))

to:

SELECT beam.id AS beam_id
FROM beam 
LEFT OUTER JOIN pin ON pin.beam_id = beam.id 
LEFT OUTER JOIN beam_type ON beam_type.id = beam.id 
LEFT OUTER JOIN file ON file.beam_id = beam.id                                                         
WHERE 
beam.pending_deletion = 0 
AND beam.deleted = 0 
AND beam.completed = 1 
AND pin.id IS NULL 
AND NOT (EXISTS (SELECT 1                                                                                          
                 FROM beam_issues JOIN issue ON issue.id = beam_issues.issue_id
                 WHERE beam_issues.beam_id = beam.id 
                 AND issue.open = 1)
        ) 
AND file.beam_id IS NULL 
AND trunc(EXTRACT(epoch FROM :param_1) - EXTRACT(epoch FROM beam.start)) / :trunc_1 >= CASE WHEN (beam.type_id IS NULL) THEN :param_2 ELSE beam_type.vacuum_threshold END
