### PR TITLE
Fix bug for windows relative paths and add tests for textual path and should compress

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -68,8 +68,8 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/cargo@v1
     - name: Install cross
-        if: matrix.os == 'ubuntu-latest'
-        run: cargo install cross
+      if: matrix.os == 'ubuntu-latest'
+      run: cargo install cross
     - working-directory: ${{ matrix.artifact }}
       run: |
         ${{ matrix.test_command }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -56,6 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         artifact: [transporter, combadge]
+        os: [linux, windows]
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/cargo@v1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -62,6 +62,7 @@ jobs:
     - working-directory: ${{ matrix.artifact }}
       run: |
         cargo check
+        cargo test
         rustup component add rustfmt clippy
         cargo fmt -- --check
         cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -67,10 +67,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/cargo@v1
+    - name: Install cross
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo install cross
     - working-directory: ${{ matrix.artifact }}
       run: |
-        cargo check
-        cargo test
+        ${{ matrix.test_command }}
         rustup component add rustfmt clippy
         cargo fmt -- --check
         cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -70,9 +70,12 @@ jobs:
     - name: Install cross
       if: matrix.os == 'ubuntu-latest'
       run: cargo install cross
-    - working-directory: ${{ matrix.artifact }}
+    - name: Lint
+      working-directory: ${{ matrix.artifact }}
       run: |
-        ${{ matrix.test_command }}
         rustup component add rustfmt clippy
         cargo fmt -- --check
         cargo clippy --all-targets --all-features -- -D warnings
+    - name: Test
+      working-directory: ${{ matrix.artifact }}
+      run: ${{ matrix.test_command }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -57,19 +57,9 @@ jobs:
       matrix:
         artifact: [transporter, combadge]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - os: ubuntu-latest
-            test_command: cross test --target x86_64-unknown-linux-musl
-          - os: windows-latest
-            test_command: cargo test
-          - os: macos-latest
-            test_command: cargo test
     steps:
     - uses: actions/checkout@v1
     - uses: hecrj/setup-rust-action@master
-    - name: Install cross
-      if: matrix.os == 'ubuntu-latest'
-      run: cargo install cross
     - name: Lint
       working-directory: ${{ matrix.artifact }}
       run: |
@@ -78,4 +68,4 @@ jobs:
         cargo clippy --all-targets --all-features -- -D warnings
     - name: Test
       working-directory: ${{ matrix.artifact }}
-      run: ${{ matrix.test_command }}
+      run: cargo test

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -66,7 +66,7 @@ jobs:
             test_command: cargo test
     steps:
     - uses: actions/checkout@v1
-    - uses: actions-rs/cargo@v1
+    - uses: hecrj/setup-rust-action@master
     - name: Install cross
       if: matrix.os == 'ubuntu-latest'
       run: cargo install cross

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -50,13 +50,20 @@ jobs:
         ./node_modules/ember-cli/bin/ember build
 
   check-artifacts:
-    name: Check ${{ matrix.artifact }}
-    runs-on: ubuntu-18.04
+    name: Check ${{ matrix.artifact }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         artifact: [transporter, combadge]
-        os: [linux, windows]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            test_command: cross test --target x86_64-unknown-linux-musl
+          - os: windows-latest
+            test_command: cargo test
+          - os: macos-latest
+            test_command: cargo test
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/cargo@v1

--- a/combadge/src/main.rs
+++ b/combadge/src/main.rs
@@ -223,6 +223,14 @@ mod test_unix {
     }
 
     #[test]
+    fn test_get_textual_path_base_path_has_subdir() {
+        assert_eq!(
+            get_textual_path(Path::new("/tmp/a/b.log"), Some(Path::new("/tmp/a")), false),
+            "./b.log"
+        )
+    }
+
+    #[test]
     fn test_should_compress_file() {
         assert!(should_compress_file(Path::new("/tmp/a.log")))
     }
@@ -275,6 +283,14 @@ mod test_windows {
         assert_eq!(
             get_textual_path(Path::new("C:\\a\\b.log"), Some(Path::new("C:\\")), false),
             ".\\a\\b.log"
+        )
+    }
+
+    #[test]
+    fn test_get_textual_path_base_path_has_subdir() {
+        assert_eq!(
+            get_textual_path(Path::new("C:\\a\\b.log"), Some(Path::new("C:\\a")), false),
+            ".\\b.log"
         )
     }
 

--- a/combadge/src/main.rs
+++ b/combadge/src/main.rs
@@ -82,14 +82,14 @@ fn should_compress_file(path: &Path) -> bool {
 }
 
 fn get_textual_path(path: &Path, base_path: Option<&Path>, should_compress: bool) -> String {
-    let path_no_base = match base_path {
+    let path_without_base = match base_path {
         Some(base_path) => path
             .strip_prefix(base_path)
             .map(|p| Path::new(".").join(p))
             .unwrap_or_else(|_| path.to_path_buf()),
         None => path.to_path_buf(),
     };
-    let mut textual_path = path_no_base.to_string_lossy().into_owned();
+    let mut textual_path = path_without_base.to_string_lossy().into_owned();
     if should_compress {
         textual_path.push_str(".gz");
     }


### PR DESCRIPTION
The bug is that for paths like "C:\a.log" the textual_path becomes ".a.log" (notice the dot at the start)
when it actually should become ".\a.log"