### PR TITLE
Fix bug with images not being tagged correctly

### DIFF
--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -98,5 +98,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: ./docker/Dockerfile
         buildargs: COMBADGE_DIR
-        tag: ${{ github.ref }}
+        tag_names: true
         overwrite: true


### PR DESCRIPTION
fixes #112 
`tag`  isn't actually a valid parameter (see https://github.com/elgohr/Publish-Docker-Github-Action) it should have been `tags` if anything, But the correct way to do what we want is actually to use `tag_names`