### PR TITLE
Fix file types to compress

### DIFF
--- a/combadge/src/main.rs
+++ b/combadge/src/main.rs
@@ -119,8 +119,9 @@ fn beam_path(transporter: &mut TcpStream, path: &Path) -> CombadgeResult<()> {
 
 fn should_compress_file(path: &Path) -> bool {
     match path.extension().and_then(OsStr::to_str) {
-        Some("zip") | Some("gz") | Some("bz2") | Some("xz") | Some("zst") | Some("tgz")
-        | Some("tbz2") | Some("txz") | Some("ioym") | Some("br") => false,
+        Some("gz") | Some("bz2") | Some("xz") | Some("zst") | Some("tgz") | Some("tbz2")
+        | Some("txz") | Some("ioym") | Some("br") | Some("png") | Some("jpg") | Some("mp3")
+        | Some("mkv") | Some("mp4") | Some("jpeg") | Some("zip") | Some("pcap") => false,
         _ => true,
     }
 }


### PR DESCRIPTION
Combadge v1 compressed far fewer file types than Combadge v2
Some examples include picture files, like png and jpg.